### PR TITLE
Add types to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "types": "types",
   "exports": {
     ".": {
-      "import": "./index.js",
-      "require": "./index.cjs"
+      "import": {
+        "default": "./index.js",
+        "types": "./types/index.d.ts"
+      },
+      "require": {
+        "default": "./index.cjs",
+        "types": "./types/index.d.ts"
+      }
     }
   },
   "repository": "https://github.com/vite-plugin/vite-plugin-multiple.git",


### PR DESCRIPTION
My Vite project is unable to resolve the types for this plugin:

```
Could not find a declaration file for module 'vite-plugin-multiple'.
'/node_modules/vite-plugin-multiple/index.js' implicitly has an 'any' type.
There are types at '/node_modules/vite-plugin-multiple/types/index.d.ts',
but this result could not be resolved when respecting package.json "exports".
The 'vite-plugin-multiple' library may need to update its package.json or typings.
```

This fix explicitly exposes the types file in the import and require export objects.

Additional info:
https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/UntypedResolution.md
https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md

